### PR TITLE
Added $vars parameter to update member

### DIFF
--- a/Services/Methods/MCList.php
+++ b/Services/Methods/MCList.php
@@ -191,7 +191,7 @@ class MCList extends HttpClient
      * 
      * @return array
      */
-    public function UpdateMember($vars = array())
+    public function UpdateMember(array $vars = array())
     {
         $payload = array('email_address' => $this->email,
                 'merge_vars' => $vars + $this->mergeVars,


### PR DESCRIPTION
Added $vars parameter to MZ\MailChimpBundle\Services\Methods\MCList::UpdateMember. This makes sense because it is on a per user basis.
