### PR TITLE
removed $listId declaration from MCCampaign glass

### DIFF
--- a/Services/Methods/MCCampaign.php
+++ b/Services/Methods/MCCampaign.php
@@ -22,7 +22,6 @@ use MZ\MailChimpBundle\Services\HttpClient;
 class MCCampaign extends HttpClient
 {
 
-    private $listId;
     private $type;
     private $subject;
     private $fromEmail;


### PR DESCRIPTION
I accedentally added the listId var which is not necessary because the extended HttpClient class already contains this protected var. (the getter and the setter are still used)
