### PR TITLE
Update MCList.php

### DIFF
--- a/Services/Methods/MCList.php
+++ b/Services/Methods/MCList.php
@@ -22,7 +22,7 @@ use MZ\MailChimpBundle\Services\HttpClient;
 class MCList extends HttpClient
 {
 
-    private $merge = null;
+    private $merge = array();
     private $emailType = 'html';
     private $doubleOptin = true;
     private $updateExisting = false;


### PR DESCRIPTION
Avoid error in function MergeVars if $merge is not set.
array_merge() returns an error if trying to merge an array and a null variable.
